### PR TITLE
Added HTML pages+graphs for BCGNWS and Geomark API hearbeats.

### DIFF
--- a/heartbeat/bcgnws/index.html
+++ b/heartbeat/bcgnws/index.html
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
 <html>
    <head>
-      <title>geocoder-public-heartbeat</title>
+      <title>bcgnws-heartbeat</title>
       <meta charset="UTF-8">
-      <meta name="description" content="Geocoder Public Heartbeat">
+      <meta name="description" content="BCGNWS Heartbeat">
       <meta name="keywords" content="HTML,CSS,JavaScript,D3">
       <link rel="stylesheet" type="text/css" href="../css/main.css">
       <script type="text/javascript" src="../lib/d3/3.5.17/d3.min.js"></script>
       <script type="text/javascript" src="../js/standard-charts.js"></script>
    </head>
    <body>
-    <script type="text/javascript">
-      makeCharts("https://raw.githubusercontent.com/bcgov/dbcrss/master/heartbeat/data/geocoder-public-heartbeat.txt", "executionTime");
-    </script>
+      <script type="text/javascript">
+        makeCharts("https://raw.githubusercontent.com/bcgov/dbcrss/master/heartbeat/data/bcgnws-heartbeat.txt", "responseTime");
+      </script>
       <h2 style="font-size:26px;" align="center">
-         BC Physical Address Geocoder (Public) Heartbeat
+         BC Geographical Names Web Service (BCGNWS) Heartbeat
       </h2>
       <h3 align="center">
-         Execution time
+         Response time
       </h3>
    </body>
 </html>

--- a/heartbeat/geocoder_sec/index.html
+++ b/heartbeat/geocoder_sec/index.html
@@ -7,11 +7,11 @@
       <meta name="keywords" content="HTML,CSS,JavaScript,D3">
       <link rel="stylesheet" type="text/css" href="../css/main.css">
       <script type="text/javascript" src="../lib/d3/3.5.17/d3.min.js"></script>
-      <script type="text/javascript" src="../js/execution-time-charts.js"></script>
+      <script type="text/javascript" src="../js/standard-charts.js"></script>
    </head>
    <body>
     <script type="text/javascript">
-      makeCharts("https://raw.githubusercontent.com/bcgov/dbcrss/master/heartbeat/data/geocoder-secure-heartbeat.txt");
+      makeCharts("https://raw.githubusercontent.com/bcgov/dbcrss/master/heartbeat/data/geocoder-secure-heartbeat.txt", "executionTime");
     </script>
       <h2 style="font-size:26px;" align="center">
          BC Physical Address Geocoder (Gated) Heartbeat

--- a/heartbeat/geomark/index.html
+++ b/heartbeat/geomark/index.html
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
 <html>
    <head>
-      <title>geocoder-public-heartbeat</title>
+      <title>geomark-heartbeat</title>
       <meta charset="UTF-8">
-      <meta name="description" content="Geocoder Public Heartbeat">
+      <meta name="description" content="Geomark Heartbeat">
       <meta name="keywords" content="HTML,CSS,JavaScript,D3">
       <link rel="stylesheet" type="text/css" href="../css/main.css">
       <script type="text/javascript" src="../lib/d3/3.5.17/d3.min.js"></script>
       <script type="text/javascript" src="../js/standard-charts.js"></script>
    </head>
    <body>
-    <script type="text/javascript">
-      makeCharts("https://raw.githubusercontent.com/bcgov/dbcrss/master/heartbeat/data/geocoder-public-heartbeat.txt", "executionTime");
-    </script>
+      <script type="text/javascript">
+        makeCharts("https://raw.githubusercontent.com/bcgov/dbcrss/master/heartbeat/data/geomark-heartbeat.txt", "responseTime");
+      </script>
       <h2 style="font-size:26px;" align="center">
-         BC Physical Address Geocoder (Public) Heartbeat
+         Geomark Heartbeat
       </h2>
       <h3 align="center">
-         Execution time
+         Response time
       </h3>
    </body>
 </html>

--- a/heartbeat/router/index.html
+++ b/heartbeat/router/index.html
@@ -7,11 +7,11 @@
       <meta name="keywords" content="HTML,CSS,JavaScript,D3">
       <link rel="stylesheet" type="text/css" href="../css/main.css">
       <script type="text/javascript" src="../lib/d3/3.5.17/d3.min.js"></script>
-      <script type="text/javascript" src="../js/execution-time-charts.js"></script>
+      <script type="text/javascript" src="../js/standard-charts.js"></script>
    </head>
    <body>
       <script type="text/javascript">
-        makeCharts("https://raw.githubusercontent.com/bcgov/dbcrss/master/heartbeat/data/router-heartbeat.txt");
+        makeCharts("https://raw.githubusercontent.com/bcgov/dbcrss/master/heartbeat/data/router-heartbeat.txt", "executionTime");
       </script>
       <h2 style="font-size:26px;" align="center">
          BC Route Planner Heartbeat


### PR DESCRIPTION
Also generalized the JS code to produce graphs with *any* one property on the y-axis.  this allows us to use the same code to graph heartbeats for APIs that don't have 'executionTime', but may have another useful property (such as responseTime).  